### PR TITLE
Add simple docker deployment guide

### DIFF
--- a/DOCKER_DEPLOY.md
+++ b/DOCKER_DEPLOY.md
@@ -1,0 +1,34 @@
+# 一键 Docker 部署指南
+
+此仓库提供了 `deploy.sh` 脚本和 `docker-compose/simple-deploy.yml`，可以在不修改源码的情况下快速部署 NocoDB。
+
+## 步骤
+
+1. **安装 Docker 与 Docker Compose**
+   - Ubuntu/Debian 示例：
+     ```bash
+     sudo apt update
+     sudo apt install docker.io docker-compose -y
+     ```
+2. **拉取代码**
+   ```bash
+   git clone https://github.com/nocodb/nocodb.git
+   cd nocodb
+   ```
+3. **执行部署脚本**
+   ```bash
+   ./deploy.sh
+   ```
+   该脚本会按 `docker-compose/simple-deploy.yml` 创建并启动容器。
+
+## 默认配置
+
+- 数据库密码：`123456`
+- `NC_PUBLIC_URL` 指向服务器地址 `http://42.192.204.166`
+- 容器对外暴露端口 `80`，访问 `http://42.192.204.166` 即可打开 NocoDB。
+- 通过设置 `LANG=zh_CN.UTF-8`，界面默认语言为中文。
+
+## 停止或更新
+
+- 停止服务：`docker compose -f docker-compose/simple-deploy.yml down`
+- 重新部署：重新执行 `./deploy.sh`

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+docker compose -f docker-compose/simple-deploy.yml up -d
+

--- a/docker-compose/simple-deploy.yml
+++ b/docker-compose/simple-deploy.yml
@@ -1,0 +1,35 @@
+version: '3'
+services:
+  nocodb:
+    image: nocodb/nocodb:latest
+    container_name: nocodb
+    environment:
+      - NC_DB=pg://db:5432?u=postgres&p=123456&d=nocodb
+      - NC_PUBLIC_URL=http://42.192.204.166
+      - LANG=zh_CN.UTF-8
+    ports:
+      - "80:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: always
+    volumes:
+      - nocodb_data:/usr/app/data
+  db:
+    image: postgres:16.6
+    container_name: nocodb-db
+    environment:
+      - POSTGRES_PASSWORD=123456
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=nocodb
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 5s
+      retries: 5
+      timeout: 2s
+    restart: always
+    volumes:
+      - db_data:/var/lib/postgresql/data
+volumes:
+  nocodb_data:
+  db_data:


### PR DESCRIPTION
## Summary
- add one-click deployment instructions in `DOCKER_DEPLOY.md`
- provide docker compose template `simple-deploy.yml`
- add `deploy.sh` helper script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a6171c318832d9ead37a9bb9e739d